### PR TITLE
refactor deps and support python3.7

### DIFF
--- a/Cumulocity/Cumulocity.py
+++ b/Cumulocity/Cumulocity.py
@@ -617,7 +617,7 @@ class Cumulocity:
         Returns:
             List[str]: List of measurements as json
 
-        Example:    
+        Example:
             |             | Command                         |   |                                                                              Result                                                                                                  |
             | ${measure}= | Device Should Have Measurements | 1 | ${measure} = [{'type': 'c8y_TemperatureMeasurement', 'time': '2023-02-02T13:30:16.343Z', 'c8y_TemperatureMeasurement': {'T': {'unit': 'C', 'value': 20}}, 'source': {'id': '55207'}}] |
         """

--- a/Cumulocity/__init__.py
+++ b/Cumulocity/__init__.py
@@ -1,5 +1,10 @@
 """Cumulocity library for Robot Framework"""
-from importlib.metadata import version, PackageNotFoundError
+import sys
+
+if sys.version_info < (3, 8):
+    from importlib_metadata import version, PackageNotFoundError
+else:
+    from importlib.metadata import version, PackageNotFoundError
 from .Cumulocity import Cumulocity
 from c8y_test_core import retry
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Reuben Miller
+Copyright (c) 2023 Reuben Miller
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
 # robotframework-c8y
 
-Robot Framework Library for Cumulocity
+Robot Framework Library for Cumulocity IoT
 
 # Using it
 
 1. Install via pip
 
     ```sh
-    pip install git+https://github.com/reubenmiller/robotframework-c8y.git@0.0.9
+    pip install git+https://github.com/reubenmiller/robotframework-c8y.git@0.11.0
     ```
 
     Or add it to your `requirements.txt` file
 
     ```sh
-    robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.0.9
+    robotframework-c8y @ git+https://github.com/reubenmiller/robotframework-c8y.git@0.11.0
     ```
 
     Then install it via

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,8 @@
 [build-system]
 requires = [
-    "setuptools>=45",
+    "setuptools>=61",
     "wheel",
-    "setuptools_scm>=6.2",
+    "setuptools-scm[toml]>=6.2",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -12,14 +12,17 @@ write_to = "Cumulocity/_version.py"
 [project]
 name = "robotframework-c8y"
 description = "Robot Framework library for Cumulocity IoT"
-requires-python = ">=3.8"
+readme = "README.md"
+requires-python = ">=3.7"
 keywords = ["CumulocityIoT", "testing"]
-license = {text = "MPL-2.0"}
+license = {text = "MIT"}
 classifiers = [
     "Programming Language :: Python :: 3",
 ]
-dynamic = ["version", "dependencies", "readme"]
-
-[tool.setuptools.dynamic]
-dependencies = {file = ["requirements.txt"]}
-readme = {file = ["README.md"]}
+dynamic = ["version"]
+dependencies = [
+  "robotframework >= 6.0.0, < 7.0.0",
+  "python-dotenv >= 0.20.0, < 0.21.0",
+  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.5.0#egg=c8y-test-core",
+  "importlib-metadata >= 6.0.0, < 7.0.0; python_version<'3.8'",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,0 @@
-robotframework~=6.0.1
-python-dotenv~=0.20.0
-c8y-api==1.4
-c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.4.0


### PR DESCRIPTION
Refactor the dependencies by moving them to the `pyproject.toml` instead of `requirements.txt`
* support python >=3.7
* change license to MIT