### PR TITLE
fix: single device registration keyword

### DIFF
--- a/Cumulocity/Cumulocity.py
+++ b/Cumulocity/Cumulocity.py
@@ -1470,7 +1470,7 @@ class Cumulocity:
 
             | Register Device With Basic Auth | MyCustomDevice0001 |
         """
-        return self.device_mgmt.registration.bulk_register_with_basic_auth(
+        return self.device_mgmt.registration.register_with_basic_auth(
             external_id=external_id,
             timeout=timeout,
             **kwargs,


### PR DESCRIPTION
Fix bug where the wrong c8y-test-core function was called when performing a single device registration using basic auth