### PR TITLE
feat: refactor delete managed object and user to only require supplying the external id and type

### DIFF
--- a/Cumulocity/Cumulocity.py
+++ b/Cumulocity/Cumulocity.py
@@ -1089,7 +1089,7 @@ class Cumulocity:
             fail(f"not enough measurements were found. args={ex.args}")
 
     @keyword("Delete Managed Object And Device User")
-    def delete_managed_object(
+    def delete_managed_object_and_device_user(
         self, external_id: str, external_id_type: str = "c8y_Serial", **kwargs
     ):
         """Delete managed object and related device user
@@ -1098,10 +1098,18 @@ class Cumulocity:
             external_id (str): External identity
             external_id_type (str, optional): External identity type. Defaults to "c8y_Serial".
         """
-        managed_object = self.device_mgmt.identity.assert_exists(
-            external_id, external_type=external_id_type, **kwargs
+        self.device_mgmt.inventory.delete_device_and_user(
+            external_id, external_id_type, **kwargs
         )
-        self.device_mgmt.inventory.delete_device_and_user(managed_object)
+
+    @keyword("Delete Managed Object")
+    def delete_managed_object(self, mo_id: str, **kwargs):
+        """Delete managed object
+
+        Args:
+            mo_id (str): Managed object id
+        """
+        self.device_mgmt.c8y.inventory.delete(mo_id)
 
     @keyword("Device Should Have Fragments")
     def assert_contains_fragments(self, *fragments: str, **kwargs) -> Dict[str, Any]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ dependencies = [
   "robotframework >= 6.0.0, < 8.0.0",
   "python-dotenv >= 1.0.0, < 1.1.0",
   "dotmap >= 1.3.30, < 1.4.0",
-  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.29.4#egg=c8y-test-core",
+  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.30.0#egg=c8y-test-core",
 ]


### PR DESCRIPTION
* "Delete Managed Object and Device user" keyword now only accepts the external id and type. If the managed object does not exist, it will still try and delete the device user
* Add a "Delete Managed Object" keyword to only delete the managed object via its id (not external id)