### PR TITLE
feat: add Upload Certificate keyword

### DIFF
--- a/Cumulocity/Cumulocity.py
+++ b/Cumulocity/Cumulocity.py
@@ -927,6 +927,32 @@ class Cumulocity:
     #
     # Trusted Certificates
     #
+    @keyword("Upload Certificate")
+    def upload_trusted_certificate(
+        self,
+        name: str,
+        pem_cert: str,
+        ignore_duplicate: bool = True,
+        **kwargs,
+    ) -> Optional[Dict[str, Any]]:
+        """Upload a certificate to Cumulocity as a trusted certificate
+
+        Examples:
+
+        | ${ops}= | Upload Certificate | name=My Root CA  | pem_cert=-----BEGIN CERTIFICATE-----... |
+        | ${ops}= | Upload Certificate | name=My Root CA  | pem_cert=-----BEGIN CERTIFICATE-----... | ignore_duplicate=${False} |
+
+        Returns:
+            Optional[Dict[str, Any]]: Response if the certificate is uploaded
+                without any errors
+        """
+        self.device_mgmt.trusted_certificates.upload_certificate(
+            name,
+            pem_cert=pem_cert,
+            ignore_duplicate=ignore_duplicate,
+            **kwargs,
+        )
+
     @keyword("Delete Device Certificate From Platform")
     def trusted_certificate_delete(self, fingerprint: str, **kwargs):
         """Delete the trusted certificate from the platform

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ dependencies = [
   "robotframework >= 6.0.0, < 8.0.0",
   "python-dotenv >= 1.0.0, < 1.1.0",
   "dotmap >= 1.3.30, < 1.4.0",
-  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.32.0#egg=c8y-test-core",
+  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.33.0#egg=c8y-test-core",
 ]


### PR DESCRIPTION
Add a new keyword, `Upload Certifcate` which allows users to upload a new certificate to Cumulocity so that it can be used to either sign leaf certificates or be used to connect to Cumulocity