### PR TITLE
fix: add auto_registration_enabled option when uploading a certificate

### DIFF
--- a/Cumulocity/Cumulocity.py
+++ b/Cumulocity/Cumulocity.py
@@ -932,6 +932,7 @@ class Cumulocity:
         self,
         name: str,
         pem_cert: str,
+        auto_registration_enabled: bool = True,
         ignore_duplicate: bool = True,
         **kwargs,
     ) -> Optional[Dict[str, Any]]:
@@ -940,6 +941,7 @@ class Cumulocity:
         Examples:
 
         | ${ops}= | Upload Certificate | name=My Root CA  | pem_cert=-----BEGIN CERTIFICATE-----... |
+        | ${ops}= | Upload Certificate | name=My Root CA  | pem_cert=-----BEGIN CERTIFICATE-----... | auto_registration_enabled=${False} |
         | ${ops}= | Upload Certificate | name=My Root CA  | pem_cert=-----BEGIN CERTIFICATE-----... | ignore_duplicate=${False} |
 
         Returns:
@@ -949,6 +951,7 @@ class Cumulocity:
         self.device_mgmt.trusted_certificates.upload_certificate(
             name,
             pem_cert=pem_cert,
+            auto_registration_enabled=auto_registration_enabled,
             ignore_duplicate=ignore_duplicate,
             **kwargs,
         )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ dependencies = [
   "robotframework >= 6.0.0, < 8.0.0",
   "python-dotenv >= 1.0.0, < 1.1.0",
   "dotmap >= 1.3.30, < 1.4.0",
-  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.33.0#egg=c8y-test-core",
+  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.33.1#egg=c8y-test-core",
 ]


### PR DESCRIPTION
Allow users to control whether the uploaded certificate should allow auto device registration or not. Defaults to True