### PR TITLE
feat: new keyword - Should Not Contain Supported Operations

### DIFF
--- a/Cumulocity/Cumulocity.py
+++ b/Cumulocity/Cumulocity.py
@@ -910,6 +910,22 @@ class Cumulocity:
             *types, **kwargs
         )
 
+    @keyword("Should Not Contain Supported Operations")
+    def operation_assert_not_contains_supported_operations(
+        self, *types: str, **kwargs
+    ) -> List[str]:
+        """Should not contain the given supported operations.
+
+        Additional supported operations that are not included in the assertion
+        may exist.
+
+        Examples:
+            | ${supported_types}= | Should Not Contain Supported Operations | c8y_Restart | c8y_SoftwareUpdate |
+        """
+        return self.device_mgmt.inventory.assert_not_contains_supported_operations(
+            *types, **kwargs
+        )
+
     @keyword("Should Have Exact Supported Operations")
     def operation_assert_supported_operations(self, *types: str, **kwargs) -> List[str]:
         """Should have exactly the given supported operations.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,5 +24,5 @@ dependencies = [
   "robotframework >= 6.0.0, < 8.0.0",
   "python-dotenv >= 1.0.0, < 1.1.0",
   "dotmap >= 1.3.30, < 1.4.0",
-  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.38.0#egg=c8y-test-core",
+  "c8y-test-core @ git+https://github.com/reubenmiller/c8y-test-core.git@0.39.0#egg=c8y-test-core",
 ]


### PR DESCRIPTION
New keyword to check that given supported operations are not present.

**Example**

```
${supported_types}=    Should Not Contain Supported Operations    c8y_Restart    c8y_SoftwareUpdate
```